### PR TITLE
Allow werkzeug to handle HTTPExceptions by itself.

### DIFF
--- a/flask_yoloapi/endpoint.py
+++ b/flask_yoloapi/endpoint.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import dateutil.parser
 from flask import jsonify, Response
+from werkzeug.exceptions import HTTPException
 from werkzeug.wrappers import Response as WResponse
 
 from flask_yoloapi import utils
@@ -128,6 +129,8 @@ def api(view_func, *parameters):
 
         try:
             result = view_func(*args, **kwargs)
+        except HTTPException:
+            raise
         except Exception as ex:
             return func_err(str(ex))
 


### PR DESCRIPTION
Currently, if an endpoint raises a werkzeug HTTPException, YoloAPI returns a 500 error with the http exception in the json body of the response.

This patch re-raises HTTPExceptions to let werkzeug natively handle the exception.